### PR TITLE
downgrade circe to 0.9.3 for compatibility reasons

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,9 +12,9 @@ lazy val buildSettings = Seq(
   releaseCrossBuild := true,
   libraryDependencies ++= {
     val specs2Version = "4.3.0"
-    val catsVersion = "1.1.0"
+    val catsVersion = "1.2.0"
     val catsEffectVersion = "0.10.1"
-    val circeVersion = "0.10.0-M1"
+    val circeVersion = "0.9.3"
 
     val amazonJavaSdks = List(    // exclude the SDKs we don't need, since they're pulled in transitively, to keep the size of the jar down
       ExclusionRule(organization = "com.amazonaws", name = "aws-java-sdk-cloudformation"),

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.1.0-SNAPSHOT"
+version in ThisBuild := "2.0.1-SNAPSHOT"


### PR DESCRIPTION
I originally tried to upgrade to circe 0.10.0-M1 to take advantage of its switch to monocle 1.5.1-cats, which removed a dependency on scalaz that wasn't being used anywhere else. (That could considerably reduce the size of the AWS Lamdba jars generated from this library.)

The problem is that a bunch of other projects in the cats/fs2/http4s ecosystem haven't upgraded to circe 0.10 yet, and 0.10 is a breaking change. Including both 0.9 and 0.10 can result in a `NoSuchMethodError` when parsing JSON.

(The previous version should probably have been published as a release candidate to allow projects to test the circe upgrade.)

This PR reverts the circe upgrade, and includes cats 1.2, [which is backward compatible with cats 1.x](https://github.com/typelevel/cats/releases/tag/v1.2.0) and therefore safe to include here.