### PR TITLE
omit nulls when writing response to CloudFormation

### DIFF
--- a/src/main/scala/com/dwolla/lambda/cloudformation/CloudFormationCustomResourceResponseWriter.scala
+++ b/src/main/scala/com/dwolla/lambda/cloudformation/CloudFormationCustomResourceResponseWriter.scala
@@ -1,8 +1,10 @@
 package com.dwolla.lambda.cloudformation
 
-import cats.effect.Async
-import io.circe.syntax._
+import cats.effect._
+import com.dwolla.lambda.cloudformation.CloudFormationCustomResourceResponseWriter._
+import io.circe._
 import io.circe.generic.auto._
+import io.circe.syntax._
 import org.apache.http.client.methods.HttpPut
 import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client._
@@ -19,7 +21,7 @@ class CloudFormationCustomResourceResponseWriter[F[_]: Async] {
   def logAndWriteToS3(presignedUri: String, cloudFormationCustomResourceResponse: CloudFormationCustomResourceResponse): F[Unit] =
     Async[F].delay {
       val req = new HttpPut(presignedUri)
-      val jsonEntity = new StringEntity(cloudFormationCustomResourceResponse.asJson.noSpaces)
+      val jsonEntity = new StringEntity(cloudFormationCustomResourceResponse.asJson.pretty(compactPrinter))
       jsonEntity.setContentType("")
 
       req.setEntity(jsonEntity)
@@ -34,4 +36,8 @@ class CloudFormationCustomResourceResponseWriter[F[_]: Async] {
         httpClient.close()
       }
     }
+}
+
+object CloudFormationCustomResourceResponseWriter {
+  private[CloudFormationCustomResourceResponseWriter] val compactPrinter = Printer.noSpaces.copy(dropNullValues = true)
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.1.0-SNAPSHOT"
+version in ThisBuild := "2.0.2-SNAPSHOT"


### PR DESCRIPTION
Without this in place, CloudFormation fails with the error “Invalid Response object: Value of property Reason must be of type String”
