### PR TITLE
Expect request types to be correctly capitalized

### DIFF
--- a/src/main/scala/com/dwolla/lambda/cloudformation/package.scala
+++ b/src/main/scala/com/dwolla/lambda/cloudformation/package.scala
@@ -40,16 +40,16 @@ package cloudformation {
     case class OtherRequestType(requestType: String) extends CloudFormationRequestType
 
     implicit val encoder: Encoder[CloudFormationRequestType] = {
-      case CreateRequest => "CREATE".asJson
-      case UpdateRequest => "UPDATE".asJson
-      case DeleteRequest => "DELETE".asJson
+      case CreateRequest => "Create".asJson
+      case UpdateRequest => "Update".asJson
+      case DeleteRequest => "Delete".asJson
       case OtherRequestType(req) => req.asJson
     }
 
     implicit val decoder: Decoder[CloudFormationRequestType] = Decoder[String].map {
-      case "CREATE" => CreateRequest
-      case "UPDATE" => UpdateRequest
-      case "DELETE" => DeleteRequest
+      case "Create" => CreateRequest
+      case "Update" => UpdateRequest
+      case "Delete" => DeleteRequest
       case other => OtherRequestType(other)
     }
   }

--- a/src/test/scala/com/dwolla/lambda/cloudformation/CloudFormationCustomResourceHandlerSpec.scala
+++ b/src/test/scala/com/dwolla/lambda/cloudformation/CloudFormationCustomResourceHandlerSpec.scala
@@ -161,7 +161,7 @@ object SampleMessages {
                  "3"
                ]
              },
-             "RequestType": "CREATE",
+             "RequestType": "Create",
              "ResourceType": "Custom::TestResource",
              "RequestId": "unique id for this create request",
              "LogicalResourceId": "MyTestResource"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.1.0-SNAPSHOT"
+version in ThisBuild := "3.0.1-SNAPSHOT"


### PR DESCRIPTION
CloudFormation requests are nicely cased, as opposed to response statuses, which are all caps 🤦‍♂️

See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-requests.html for reference.